### PR TITLE
fix(fetchCodeOwnersContent): use default branch from codeowners repo

### DIFF
--- a/cmd/emoji-gate/main.go
+++ b/cmd/emoji-gate/main.go
@@ -15,7 +15,7 @@ func fetchCodeOwnersContent(client GitlabClientInterface, cfg GitlabConfig, proj
 		if err != nil {
 			return "", fmt.Errorf("failed to get codeowners project: %w", err)
 		}
-		return client.GetFileContent(codeOwnersRepo.ID, project.DefaultBranch, cfg.CodeOwnersPath)
+		return client.GetFileContent(codeOwnersRepo.ID, codeOwnersRepo.DefaultBranch, cfg.CodeOwnersPath)
 	}
 	return client.GetFileContent(project.ID, project.DefaultBranch, cfg.CodeOwnersPath)
 }


### PR DESCRIPTION
Currently, we are using `default_branch` from the repo that has triggered the binary, but with `CODEOWNERS_REPO`, it's not a reasonable approach. This fix resolves the problem.